### PR TITLE
Pin OpenScale version to 1.0.429 .

### DIFF
--- a/notebooks/DataMart.ipynb
+++ b/notebooks/DataMart.ipynb
@@ -52,7 +52,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --upgrade ibm-ai-openscale"
+    "!pip install ibm-ai-openscale==1.0.429 --no-cache | tail -n 1"
    ]
   },
   {


### PR DESCRIPTION
New notebook for version 2.x will follow after testing and updates
for new data set.
This is a workaround.