### PR TITLE
Document need for OpenScale in Dallas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ KEEP_MY_INTERNAL_POSTGRES = False
 
 ### 3. Create a Watson OpenScale service
 
+> NOTE: At this time (3/27/19) you must use an instance of Watson OpenScale deployed in the `Dallas` region. This is currently the only region that sends events about scoring requests to the message hub, which is read by OpenScale to populate the payload logging table.
+
 * Using the [IBM Cloud Dashboard]() create a [Watson OpenScale](https://cloud.ibm.com/catalog/services/ai-openscale) service.
 * You will get the Watson OpenScale instance GUID when you run the notebook using the [IBM Cloud CLI](https://cloud.ibm.com/catalog/services/ai-openscale)
 


### PR DESCRIPTION
At this time (3/27/19) you must use an instance of Watson OpenScale
deployed in the `Dallas` region. This is currently the only region
that sends events about scoring requests to the message hub, which
is read by OpenScale to populate the payload logging table.

Closes: #35